### PR TITLE
Allow customisable stream

### DIFF
--- a/cursor/cursor.py
+++ b/cursor/cursor.py
@@ -26,7 +26,7 @@ if os.name == 'nt':
         _fields_ = [("size", ctypes.c_int),
                     ("visible", ctypes.c_byte)]
 
-def hide():
+def hide(stream=sys.stdout):
     if os.name == 'nt':
         ci = _CursorInfo()
         handle = ctypes.windll.kernel32.GetStdHandle(-11)
@@ -34,10 +34,10 @@ def hide():
         ci.visible = False
         ctypes.windll.kernel32.SetConsoleCursorInfo(handle, ctypes.byref(ci))
     elif os.name == 'posix':
-        sys.stdout.write("\033[?25l")
-        sys.stdout.flush()
+        stream.write("\033[?25l")
+        stream.flush()
 
-def show():
+def show(stream=sys.stdout):
     if os.name == 'nt':
         ci = _CursorInfo()
         handle = ctypes.windll.kernel32.GetStdHandle(-11)
@@ -45,11 +45,13 @@ def show():
         ci.visible = True
         ctypes.windll.kernel32.SetConsoleCursorInfo(handle, ctypes.byref(ci))
     elif os.name == 'posix':
-        sys.stdout.write("\033[?25h")
-        sys.stdout.flush()
+        stream.write("\033[?25h")
+        stream.flush()
         
 class HiddenCursor(object):
+    def __init__(self, stream=sys.stdout):
+        self._stream = stream
     def __enter__(self):
-        hide()
+        hide(stream=self._stream)
     def __exit__(self, type, value, traceback):
-        show()
+        show(stream=self._stream)

--- a/examples/stream_change.py
+++ b/examples/stream_change.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+"""Example for stream changing
+"""
+from __future__ import unicode_literals, absolute_import, print_function
+import os
+import time
+import sys
+
+os.sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import cursor
+
+cursor.hide(stream=sys.stderr)  # Hides the cursor
+cursor.show(stream=sys.stderr)  # Shows the cursor
+
+with cursor.HiddenCursor(stream=sys.stderr):  # Cursor will stay hidden
+    import time  # while code is being executed;
+    for a in range(1, 100):  # afterwards it will show up again
+        print(a)
+        time.sleep(0.05)


### PR DESCRIPTION
Currently, escape sequences are outputted to stdout which is not customizable. This PR fixes and allows users to select the stream themselves.

Fixes #2 